### PR TITLE
Fix layout for Google Chrome/Chromium browsers

### DIFF
--- a/assets/stylesheets/styles.css
+++ b/assets/stylesheets/styles.css
@@ -7,7 +7,6 @@ body {
 }
 
 .container {
-  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
Footer is not displayed correctly in Google Chrome / Chromium browsers. See the attached screenshot.

![layout](https://user-images.githubusercontent.com/1512987/46379098-1a1c6100-c69e-11e8-8697-d18d8002d40c.png)

Happy #Hacktoberfest